### PR TITLE
Removed Unnecessary php-closing tag according new php coding style.

### DIFF
--- a/src/PECL/RomaClient.php
+++ b/src/PECL/RomaClient.php
@@ -525,5 +525,3 @@ class RomaClient {
     /*     /\* return $result; *\/ */
     /*   throw new Exception("Not implements !"); */
     /* } */
-
-?> 


### PR DESCRIPTION
 it was causing problem in Packet crafting.  Reference : http://php.net/basic-syntax.phptags :+1: 
and https://wiki.php.net/rfc/remove_alternative_php_tags
